### PR TITLE
[DON'T MERGE] wip spiking some ideas for the api client

### DIFF
--- a/app/controllers/complete_curriculum_programs_controller.rb
+++ b/app/controllers/complete_curriculum_programs_controller.rb
@@ -1,0 +1,9 @@
+class CompleteCurriculumProgramsController < ApplicationController
+  def index
+    @complete_curriculum_programs = CompleteCurriculumProgram.index
+  end
+
+  def show
+    @complete_curriculum_program = CompleteCurriculumProgram.show params[:id]
+  end
+end

--- a/app/controllers/lessons_controller.rb
+++ b/app/controllers/lessons_controller.rb
@@ -1,0 +1,5 @@
+class LessonsController < ApplicationController
+  def show
+    @lesson = Lesson.show params[:id]
+  end
+end

--- a/app/controllers/units_controller.rb
+++ b/app/controllers/units_controller.rb
@@ -1,0 +1,5 @@
+class UnitsController < ApplicationController
+  def show
+    @unit = Unit.show params[:id]
+  end
+end

--- a/app/models/api_client.rb
+++ b/app/models/api_client.rb
@@ -1,0 +1,84 @@
+class ApiClient
+  def self.get(url)
+    case url
+    when /\A\/ccps\Z/
+      [
+        {
+          "id": 101,
+          "name": "Year 7 Geography",
+          "overview": "What is to be covered...",
+          "benefits": "The pupils learnings will benefit..."
+        }
+      ]
+    when /\A\/ccps\/(\d+)\Z/
+        {
+          "id": $1,
+          "name": "Year 7 Geography",
+          "overview": "What is to be covered...",
+          "benefits": "The pupils learnings will benefit..."
+        }
+    when /\A\/ccps\/(\d+)\/units\Z/
+      [
+        {
+          "id": 101,
+          "complete_curriculum_program_id": $1,
+          "name": "Volcanos, earthquakes and plates",
+          "overview": "A unit focused on the physical processes that create and destroy our landscape - and their effects on humans.",
+          "benefits": "The lessons in this unit have been planned progressively to enable pupils to retain powerful knowledge and vocabulary that can be used confidently later in life. Progressively planned learning enables children to apply prior knowledge and build upon it. This approach solidifies learning beyond learning facts in the classroom, allowing knowledge to be stored in pupils’ long-term memories."
+        }
+      ]
+    when /\A\/units\/(\d+)\Z/
+      {
+        "id": $1,
+        "complete_curriculum_program_id": 101,
+        "name": "Volcanos, earthquakes and plates",
+        "overview": "A unit focused on the physical processes that create and destroy our landscape - and their effects on humans.",
+        "benefits": "The lessons in this unit have been planned progressively to enable pupils to retain powerful knowledge and vocabulary that can be used confidently later in life. Progressively planned learning enables children to apply prior knowledge and build upon it. This approach solidifies learning beyond learning facts in the classroom, allowing knowledge to be stored in pupils’ long-term memories."
+      }
+    when /\A\/units\/(\d+)\/lessons\Z/
+      [
+        {
+          "id": 101,
+          "complete_curriculum_program_id": 101,
+          "unit_id": $1,
+          "name": "Types of volcanoes",
+          "sequence_no": 0,
+          "summary": "Objective - To learn the types of volcanoes",
+          "core_knowledge": "Pupils should know that...",
+          "vocabulary": [
+            "cone",
+            "vent",
+            "magma chamber"
+          ],
+          "misconceptions": [
+            "all volcanoes erupt violently",
+            "if a volcano doesnt erupt in a hundred years its extinct"
+          ],
+          "previous_knowledge": "Pupils should already know that..."
+        }
+      ]
+    when /\A\/lessons\/(\d+)\Z/
+      {
+        "id": $1,
+        "complete_curriculum_program_id": 101,
+        "unit_id": 101,
+        "name": "Types of volcanoes",
+        "sequence_no": 0,
+        "summary": "Objective - To learn the types of volcanoes",
+        "core_knowledge": "Pupils should know that...",
+        "vocabulary": [
+          "cone",
+          "vent",
+          "magma chamber"
+        ],
+        "misconceptions": [
+          "all volcanoes erupt violently",
+          "if a volcano doesnt erupt in a hundred years its extinct"
+        ],
+        "previous_knowledge": "Pupils should already know that..."
+      }
+    else
+      fail %{Unknown endpoint #{url}}
+    end
+  end
+end

--- a/app/models/complete_curriculum_program.rb
+++ b/app/models/complete_curriculum_program.rb
@@ -1,0 +1,33 @@
+class CompleteCurriculumProgram
+  include ActiveModel::Model
+  include ActiveModel::Attributes
+
+  attribute :id, :integer
+  attribute :name, :string
+  attribute :overview, :string
+  attribute :benefits, :string
+
+  validates :id, :name, :overview, :benefits, presence: true
+
+  def self.api_client
+    ApiClient
+  end
+
+  def self.index
+    end_point = '/ccps'
+    api_client.get(end_point).map(&method(:new)).map { |m| m.tap(&:validate!) }
+  end
+
+  def self.show(id)
+    end_point = ['/ccps', id].join("/")
+    new(api_client.get(end_point)).tap(&:validate!)
+  end
+
+  def persisted?
+    id.present?
+  end
+
+  def units
+    Unit.index id
+  end
+end

--- a/app/models/lesson.rb
+++ b/app/models/lesson.rb
@@ -1,0 +1,32 @@
+class Lesson
+  include ActiveModel::Model
+  include ActiveModel::Attributes
+
+  attribute :id, :integer
+  attribute :unit_id, :integer
+  attribute :complete_curriculum_program_id, :integer
+  attribute :name, :string
+  attribute :sequence_no, :integer
+  attribute :summary, :string
+  attribute :core_knowledge, :string
+  attribute :previous_knowledge, :string
+  attr_accessor :vocabulary, :misconceptions # TODO register new AM::Types
+
+  def self.api_client
+    ApiClient
+  end
+
+  def self.index(unit_id)
+    end_point = ['/units', unit_id, 'lessons'].join('/')
+    api_client.get(end_point).map(&method(:new)).map { |m| m.tap(&:validate!) }
+  end
+
+  def self.show(id)
+    end_point = ['/lessons', id].join("/")
+    new(api_client.get(end_point)).tap(&:validate!)
+  end
+
+  def persisted?
+    id.present?
+  end
+end

--- a/app/models/unit.rb
+++ b/app/models/unit.rb
@@ -1,0 +1,34 @@
+class Unit
+  include ActiveModel::Model
+  include ActiveModel::Attributes
+
+  attribute :id, :integer
+  attribute :complete_curriculum_program_id, :integer
+  attribute :name, :string
+  attribute :overview, :string
+  attribute :benefits, :string
+
+  validates :id, :name, :overview, :benefits, presence: true
+
+  def self.api_client
+    ApiClient
+  end
+
+  def self.index(complete_curriculum_program_id)
+    end_point = ['/ccps', complete_curriculum_program_id, 'units'].join('/')
+    api_client.get(end_point).map(&method(:new)).map { |m| m.tap(&:validate!) }
+  end
+
+  def self.show(id)
+    end_point = ['/units', id].join("/")
+    new(api_client.get(end_point)).tap(&:validate!)
+  end
+
+  def persisted?
+    id.present?
+  end
+
+  def lessons
+    Lesson.index id
+  end
+end

--- a/app/views/complete_curriculum_programs/index.slim
+++ b/app/views/complete_curriculum_programs/index.slim
@@ -1,0 +1,3 @@
+h1 Programs
+- @complete_curriculum_programs.each do |ccp|
+  = link_to ccp.name, ccp

--- a/app/views/complete_curriculum_programs/show.slim
+++ b/app/views/complete_curriculum_programs/show.slim
@@ -1,0 +1,6 @@
+h1 = @complete_curriculum_program.name
+
+h2 Units
+ul
+- @complete_curriculum_program.units.each do |unit|
+  li = link_to unit.name, unit

--- a/app/views/lessons/show.slim
+++ b/app/views/lessons/show.slim
@@ -1,0 +1,23 @@
+h1 = @lesson.name
+
+table
+  tbody
+    tr
+      td summary
+      td = @lesson.summary
+    tr
+      td core_knowledge
+      td = @lesson.core_knowledge
+    tr
+      td previous_knowledge
+      td = @lesson.previous_knowledge
+
+h2 vocabulary
+ul
+  - @lesson.vocabulary.each do |v|
+    li = v
+
+h2 misconceptions
+ul
+  - @lesson.misconceptions.each do |m|
+    li = m

--- a/app/views/units/show.slim
+++ b/app/views/units/show.slim
@@ -1,0 +1,6 @@
+h1 = @unit.name
+
+h2 Lessons
+
+- @unit.lessons.each do |lesson|
+  li = link_to lesson.name, lesson

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,6 +7,12 @@ Rails.application.routes.draw do
   resource :sessions, only: %i(create destroy)
   get '/sessions/:token', to: 'sessions#create'
 
+  resources :complete_curriculum_programs, only: %i(show index) do
+    resources :units, only: %i(show), shallow: true do
+      resources :lessons, only: %i(show), shallow: true
+    end
+  end
+
   # temporary routes used for testing while setting up
   resource :protected, controller: :protected, only: %i(show)
   resource :sentry_test, controller: :sentry_test, only: %i(show)


### PR DESCRIPTION
# Just testing some ideas to see what works best, don't merge!

Visit https://dfe-curricul-api-models-yk3inm.herokuapp.com/complete_curriculum_programs and you should be able to click through the app.

## Changes from the draft api spec
I'm assuming shallow routes on the api as this saves us having horribly long `link_to` arguments in the views. Though I do think we could do some stuff with overwriting `to_param` to include the ancestors id's if we're not having shallow routes on the backend.
Also I've underscored the camelised attribute names.

I think we'll end up wanting to including child resources in responses from the backend otherwise each view will require two api calls to render. Additionally this current approach is triggering an api call from the view which seems pretty bad but again this is just a spike.